### PR TITLE
Use github.event_name instead of github.event.name

### DIFF
--- a/.github/workflows/anime_movie.yml
+++ b/.github/workflows/anime_movie.yml
@@ -33,4 +33,4 @@ jobs:
           bundle exec rake anime_movie
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-          GITHUB_EVENT_NAME: ${{ github.event.name }}
+          GITHUB_EVENT_NAME: ${{ github.event_name }}

--- a/.github/workflows/today_anime.yml
+++ b/.github/workflows/today_anime.yml
@@ -33,4 +33,4 @@ jobs:
           bundle exec rake today_anime
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-          GITHUB_EVENT_NAME: ${{ github.event.name }}
+          GITHUB_EVENT_NAME: ${{ github.event_name }}


### PR DESCRIPTION
`github.event.name` is undocumented...

https://help.github.com/en/articles/contexts-and-expression-syntax-for-github-actions#github-context