### PR TITLE
Upgrade to slack-notifier v2.4.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ gem "activesupport", require: "active_support/all"
 gem "hpricot"
 gem "libxml-ruby"
 gem "rake", require: false
-gem "slack-notifier", github: "fusic/slack-notifier", branch: "resolve_warning_ruby27" # c.f. https://github.com/stevenosloan/slack-notifier/pull/119
+gem "slack-notifier", ">= 2.4.0"
 gem "syobocalite", ">= 1.0.0"
 gem "syoboi_calendar"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,10 +1,3 @@
-GIT
-  remote: https://github.com/fusic/slack-notifier
-  revision: 91b11278911d32199d4349ff0a59fdd7d63e9e8d
-  branch: resolve_warning_ruby27
-  specs:
-    slack-notifier (2.3.2)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -40,6 +33,7 @@ GEM
       pry (~> 0.13.0)
     rake (13.0.3)
     ruby2_keywords (0.0.2)
+    slack-notifier (2.4.0)
     syobocalite (1.0.0)
       activesupport
       multi_xml
@@ -60,9 +54,9 @@ DEPENDENCIES
   libxml-ruby
   pry-byebug
   rake
-  slack-notifier!
+  slack-notifier (>= 2.4.0)
   syobocalite (>= 1.0.0)
   syoboi_calendar
 
 BUNDLED WITH
-   2.1.4
+   2.2.3


### PR DESCRIPTION
latest slack-notifier supports Ruby 3.0

https://github.com/slack-notifier/slack-notifier/blob/main/changelog.md#240