### PR TITLE
Fixed `Faraday::TimeoutError: Net::ReadTimeout with #<TCPSocket:(closed)> (Faraday::TimeoutError)`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,4 +11,3 @@ gem "multi_xml"
 gem "rake", require: false
 gem "slack-notifier", ">= 2.4.0"
 gem "syobocalite", ">= 1.0.0"
-gem "syoboi_calendar"

--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
 gem "activesupport", require: "active_support/all"
 gem "libxml-ruby"
 gem "mechanize"
+gem "multi_xml"
 gem "rake", require: false
 gem "slack-notifier", ">= 2.4.0"
 gem "syobocalite", ">= 1.0.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -102,6 +102,7 @@ DEPENDENCIES
   activesupport
   libxml-ruby
   mechanize
+  multi_xml
   rake
   slack-notifier (>= 2.4.0)
   syobocalite (>= 1.0.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -19,31 +19,6 @@ GEM
     connection_pool (2.4.1)
     domain_name (0.6.20240107)
     drb (2.2.1)
-    faraday (1.10.3)
-      faraday-em_http (~> 1.0)
-      faraday-em_synchrony (~> 1.0)
-      faraday-excon (~> 1.1)
-      faraday-httpclient (~> 1.0)
-      faraday-multipart (~> 1.0)
-      faraday-net_http (~> 1.0)
-      faraday-net_http_persistent (~> 1.0)
-      faraday-patron (~> 1.0)
-      faraday-rack (~> 1.0)
-      faraday-retry (~> 1.0)
-      ruby2_keywords (>= 0.0.4)
-    faraday-em_http (1.0.0)
-    faraday-em_synchrony (1.0.0)
-    faraday-excon (1.1.0)
-    faraday-httpclient (1.0.1)
-    faraday-multipart (1.0.4)
-      multipart-post (~> 2)
-    faraday-net_http (1.0.1)
-    faraday-net_http_persistent (1.2.0)
-    faraday-patron (1.0.0)
-    faraday-rack (1.0.0)
-    faraday-retry (1.0.3)
-    faraday_middleware (1.2.0)
-      faraday (~> 1.0)
     http-cookie (1.0.5)
       domain_name (~> 0.5)
     i18n (1.14.4)
@@ -68,7 +43,6 @@ GEM
     mini_portile2 (2.8.5)
     minitest (5.22.3)
     multi_xml (0.6.0)
-    multipart-post (2.4.0)
     mutex_m (0.2.0)
     net-http-digest_auth (1.4.1)
     net-http-persistent (4.0.2)
@@ -80,15 +54,10 @@ GEM
     public_suffix (5.0.5)
     racc (1.7.3)
     rake (13.2.1)
-    ruby2_keywords (0.0.5)
     rubyntlm (0.6.3)
     slack-notifier (2.4.0)
     syobocalite (1.0.1)
       activesupport
-      multi_xml
-    syoboi_calendar (0.9.4)
-      faraday
-      faraday_middleware
       multi_xml
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
@@ -106,7 +75,6 @@ DEPENDENCIES
   rake
   slack-notifier (>= 2.4.0)
   syobocalite (>= 1.0.0)
-  syoboi_calendar
 
 BUNDLED WITH
    2.5.3


### PR DESCRIPTION
https://app.circleci.com/pipelines/github/ruby-jp/anime_bot/1762/workflows/23f661b0-f888-4e6e-ad81-82e7f3bfff42/jobs/2021

```
Faraday::TimeoutError: Net::ReadTimeout with #<TCPSocket:(closed)> (Faraday::TimeoutError)
/home/circleci/app/vendor/bundle/ruby/3.3.0/gems/faraday-net_http-1.0.1/lib/faraday/adapter/net_http.rb:139:in `block in request_via_get_method'
/home/circleci/app/vendor/bundle/ruby/3.3.0/gems/faraday-net_http-1.0.1/lib/faraday/adapter/net_http.rb:138:in `request_via_get_method'
/home/circleci/app/vendor/bundle/ruby/3.3.0/gems/faraday-net_http-1.0.1/lib/faraday/adapter/net_http.rb:129:in `request_with_wrapped_block'
/home/circleci/app/vendor/bundle/ruby/3.3.0/gems/faraday-net_http-1.0.1/lib/faraday/adapter/net_http.rb:122:in `perform_request'
/home/circleci/app/vendor/bundle/ruby/3.3.0/gems/faraday-net_http-1.0.1/lib/faraday/adapter/net_http.rb:66:in `block in call'
/home/circleci/app/vendor/bundle/ruby/3.3.0/gems/faraday-1.10.3/lib/faraday/adapter.rb:50:in `connection'
/home/circleci/app/vendor/bundle/ruby/3.3.0/gems/faraday-net_http-1.0.1/lib/faraday/adapter/net_http.rb:64:in `call'
/home/circleci/app/vendor/bundle/ruby/3.3.0/gems/faraday_middleware-1.2.0/lib/faraday_middleware/response_middleware.rb:36:in `call'
/home/circleci/app/vendor/bundle/ruby/3.3.0/gems/faraday-1.10.3/lib/faraday/rack_builder.rb:154:in `build_response'
/home/circleci/app/vendor/bundle/ruby/3.3.0/gems/faraday-1.10.3/lib/faraday/connection.rb:516:in `run_request'
/home/circleci/app/vendor/bundle/ruby/3.3.0/gems/faraday-1.10.3/lib/faraday/connection.rb:202:in `get'
/home/circleci/app/vendor/bundle/ruby/3.3.0/gems/syoboi_calendar-0.9.4/lib/syoboi_calendar/client.rb:63:in `get'
/home/circleci/app/vendor/bundle/ruby/3.3.0/gems/syoboi_calendar-0.9.4/lib/syoboi_calendar/client.rb:73:in `list'
/home/circleci/app/vendor/bundle/ruby/3.3.0/gems/syoboi_calendar-0.9.4/lib/syoboi_calendar/client.rb:40:in `list_programs'
/home/circleci/app/lib/syobocalite_ext.rb:62:in `flag'
/home/circleci/app/lib/syobocalite_ext.rb:42:in `new?'
/home/circleci/app/lib/syobocalite_ext.rb:29:in `display_flag'
/home/circleci/app/lib/syobocalite_ext.rb:17:in `format'
/home/circleci/app/lib/today_anime.rb:35:in `block in perform'
/home/circleci/app/lib/today_anime.rb:34:in `each'
/home/circleci/app/lib/today_anime.rb:34:in `each_with_object'
/home/circleci/app/lib/today_anime.rb:34:in `perform'
/home/circleci/app/lib/today_anime.rb:12:in `block in perform_all'
/home/circleci/app/lib/today_anime.rb:11:in `each'
/home/circleci/app/lib/today_anime.rb:11:in `perform_all'
/home/circleci/app/Rakefile:4:in `block in <top (required)>'
/home/circleci/app/vendor/bundle/ruby/3.3.0/gems/rake-13.2.1/exe/rake:27:in `<top (required)>'
/home/circleci/.rubygems/gems/bundler-2.5.3/lib/bundler/cli/exec.rb:58:in `load'
/home/circleci/.rubygems/gems/bundler-2.5.3/lib/bundler/cli/exec.rb:58:in `kernel_load'
/home/circleci/.rubygems/gems/bundler-2.5.3/lib/bundler/cli/exec.rb:23:in `run'
/home/circleci/.rubygems/gems/bundler-2.5.3/lib/bundler/cli.rb:451:in `exec'
/home/circleci/.rubygems/gems/bundler-2.5.3/lib/bundler/vendor/thor/lib/thor/command.rb:28:in `run'
/home/circleci/.rubygems/gems/bundler-2.5.3/lib/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'
/home/circleci/.rubygems/gems/bundler-2.5.3/lib/bundler/vendor/thor/lib/thor.rb:527:in `dispatch'
/home/circleci/.rubygems/gems/bundler-2.5.3/lib/bundler/cli.rb:34:in `dispatch'
/home/circleci/.rubygems/gems/bundler-2.5.3/lib/bundler/vendor/thor/lib/thor/base.rb:584:in `start'
/home/circleci/.rubygems/gems/bundler-2.5.3/lib/bundler/cli.rb:28:in `start'
/home/circleci/.rubygems/gems/bundler-2.5.3/exe/bundle:28:in `block in <top (required)>'
/home/circleci/.rubygems/gems/bundler-2.5.3/lib/bundler/friendly_errors.rb:117:in `with_friendly_errors'
/home/circleci/.rubygems/gems/bundler-2.5.3/exe/bundle:20:in `<top (required)>'
/home/circleci/.rubygems/bin/bundle:25:in `load'
/home/circleci/.rubygems/bin/bundle:25:in `<main>'

Caused by:
Net::ReadTimeout: Net::ReadTimeout with #<TCPSocket:(closed)> (Net::ReadTimeout)
/home/circleci/app/vendor/bundle/ruby/3.3.0/gems/faraday-net_http-1.0.1/lib/faraday/adapter/net_http.rb:139:in `block in request_via_get_method'
/home/circleci/app/vendor/bundle/ruby/3.3.0/gems/faraday-net_http-1.0.1/lib/faraday/adapter/net_http.rb:138:in `request_via_get_method'
/home/circleci/app/vendor/bundle/ruby/3.3.0/gems/faraday-net_http-1.0.1/lib/faraday/adapter/net_http.rb:129:in `request_with_wrapped_block'
/home/circleci/app/vendor/bundle/ruby/3.3.0/gems/faraday-net_http-1.0.1/lib/faraday/adapter/net_http.rb:122:in `perform_request'
/home/circleci/app/vendor/bundle/ruby/3.3.0/gems/faraday-net_http-1.0.1/lib/faraday/adapter/net_http.rb:66:in `block in call'
/home/circleci/app/vendor/bundle/ruby/3.3.0/gems/faraday-1.10.3/lib/faraday/adapter.rb:50:in `connection'
/home/circleci/app/vendor/bundle/ruby/3.3.0/gems/faraday-net_http-1.0.1/lib/faraday/adapter/net_http.rb:64:in `call'
/home/circleci/app/vendor/bundle/ruby/3.3.0/gems/faraday_middleware-1.2.0/lib/faraday_middleware/response_middleware.rb:36:in `call'
/home/circleci/app/vendor/bundle/ruby/3.3.0/gems/faraday-1.10.3/lib/faraday/rack_builder.rb:154:in `build_response'
/home/circleci/app/vendor/bundle/ruby/3.3.0/gems/faraday-1.10.3/lib/faraday/connection.rb:516:in `run_request'
/home/circleci/app/vendor/bundle/ruby/3.3.0/gems/faraday-1.10.3/lib/faraday/connection.rb:202:in `get'
/home/circleci/app/vendor/bundle/ruby/3.3.0/gems/syoboi_calendar-0.9.4/lib/syoboi_calendar/client.rb:63:in `get'
/home/circleci/app/vendor/bundle/ruby/3.3.0/gems/syoboi_calendar-0.9.4/lib/syoboi_calendar/client.rb:73:in `list'
/home/circleci/app/vendor/bundle/ruby/3.3.0/gems/syoboi_calendar-0.9.4/lib/syoboi_calendar/client.rb:40:in `list_programs'
/home/circleci/app/lib/syobocalite_ext.rb:62:in `flag'
/home/circleci/app/lib/syobocalite_ext.rb:42:in `new?'
/home/circleci/app/lib/syobocalite_ext.rb:29:in `display_flag'
/home/circleci/app/lib/syobocalite_ext.rb:17:in `format'
/home/circleci/app/lib/today_anime.rb:35:in `block in perform'
/home/circleci/app/lib/today_anime.rb:34:in `each'
/home/circleci/app/lib/today_anime.rb:34:in `each_with_object'
/home/circleci/app/lib/today_anime.rb:34:in `perform'
/home/circleci/app/lib/today_anime.rb:12:in `block in perform_all'
/home/circleci/app/lib/today_anime.rb:11:in `each'
/home/circleci/app/lib/today_anime.rb:11:in `perform_all'
/home/circleci/app/Rakefile:4:in `block in <top (required)>'
/home/circleci/app/vendor/bundle/ruby/3.3.0/gems/rake-13.2.1/exe/rake:27:in `<top (required)>'
/home/circleci/.rubygems/gems/bundler-2.5.3/lib/bundler/cli/exec.rb:58:in `load'
/home/circleci/.rubygems/gems/bundler-2.5.3/lib/bundler/cli/exec.rb:58:in `kernel_load'
/home/circleci/.rubygems/gems/bundler-2.5.3/lib/bundler/cli/exec.rb:23:in `run'
/home/circleci/.rubygems/gems/bundler-2.5.3/lib/bundler/cli.rb:451:in `exec'
/home/circleci/.rubygems/gems/bundler-2.5.3/lib/bundler/vendor/thor/lib/thor/command.rb:28:in `run'
/home/circleci/.rubygems/gems/bundler-2.5.3/lib/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'
/home/circleci/.rubygems/gems/bundler-2.5.3/lib/bundler/vendor/thor/lib/thor.rb:527:in `dispatch'
/home/circleci/.rubygems/gems/bundler-2.5.3/lib/bundler/cli.rb:34:in `dispatch'
/home/circleci/.rubygems/gems/bundler-2.5.3/lib/bundler/vendor/thor/lib/thor/base.rb:584:in `start'
/home/circleci/.rubygems/gems/bundler-2.5.3/lib/bundler/cli.rb:28:in `start'
/home/circleci/.rubygems/gems/bundler-2.5.3/exe/bundle:28:in `block in <top (required)>'
/home/circleci/.rubygems/gems/bundler-2.5.3/lib/bundler/friendly_errors.rb:117:in `with_friendly_errors'
/home/circleci/.rubygems/gems/bundler-2.5.3/exe/bundle:20:in `<top (required)>'
/home/circleci/.rubygems/bin/bundle:25:in `load'
/home/circleci/.rubygems/bin/bundle:25:in `<main>'
Tasks: TOP => today_anime
(See full trace by running task with --trace)
```